### PR TITLE
Drop .js extension to play nice with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-websockets",
   "version": "1.3.0",
   "description": "A WebSocket NativeScript module for Android",
-  "main": "websockets.js",
+  "main": "websockets",
   "nativescript": {
 	"platforms": {
 		"android": "1.4.0",


### PR DESCRIPTION
Webpack fails to find this plugin because of the `.js` extension in `main` in package.json (it is actually looking for a file named `websockets.js.android.js`).

As per http://docs.nativescript.org/tooling/bundling-with-webpack#recommendations-for-plugin-authors I have removed the extension.