### PR TITLE
iOS: TypeError: null is not an object (evaluating 'this.wrapper._notify')

### DIFF
--- a/src/websockets.ios.js
+++ b/src/websockets.ios.js
@@ -25,9 +25,15 @@ var _WebSocket = NSObject.extend({
     wrapper: null,
 
     webSocketDidOpen: function(webSocket) {
+        if (!this.wrapper) {
+            return;
+        }
         this.wrapper._notify("open", [this.wrapper]);
     },
     webSocketDidReceiveMessage: function(webSocket, message) {
+        if (!this.wrapper) {
+            return;
+        }
         if (Object.prototype.toString.apply(message) === "[object NSConcreteMutableData]") {
             // This is a HACK currently; but after benchmarking it --
             // it is much faster than I would have expected.
@@ -54,12 +60,18 @@ var _WebSocket = NSObject.extend({
         this.wrapper._notify("message", [this.wrapper, message]);
     },
     webSocketDidFailWithError: function(webSocket, err) {
+        if (!this.wrapper) {
+           return;
+        }
         this.wrapper._notify("close", [this.wrapper, 1006, "", false]);
         if (!err || err.code !== 3 && err.code !== 54) {
             this.wrapper._notify("error", [this.wrapper, err]);
         }
     },
     webSocketDidCloseWithCodeReasonWasClean:function(webSocket, code, reason, wasClean)  {
+        if (!this.wrapper) {
+            return;
+        }
         this.wrapper._notify("close", [this.wrapper, code, reason, wasClean]);
     }
 },{ protocols: [PSWebSocketDelegate] });


### PR DESCRIPTION
The following error is occurring which is resulting in NativeScript iOS application crashing...
 ```
    TypeError: null is not an object (evaluating 'this.wrapper._notify')
      at webSocketDidFailWithError(/app/bundle.js:22148:21)
      at UIApplicationMain([native code])
      at ...
```
This is happening very infrequently and is very hard to reproduce (I've been catching it from error reporting being done by applications out in the wild).

The code that is triggering the crash is basically...
```
    var ws = new WebSocket(this.server.ws_uri, 'sip');
    ...
    ws.close();
    ws = null;
 ```
The JavaScript instance of the PSWebSocket delegate holds an internal reference to 'ws' (as 'wrapper'). It seems the native instance of the delegate is being posted a message but the javascript instance is gone. I don't have my head around how garbage collection is being done in this case, but some garbage collection issue/race between native & javascript is my only guess. I did not pin down the exact conditions when this is happening and from reading the code it seems impossible that it could happen (thus the native/javascript gc speculation), but it is definitely happening (infrequently and randomly) across a range of iOS devices running a NativeScript 3.4.1 application.

Anyway, the patch adds guards which have empirically resolved the issue. The only callback in which I've actually seen the issue is in webSocketDidFailWithError(), but added guards to all the callbacks just cause.