### PR TITLE
Declare fully qualified name for the generated Java subclass.

### DIFF
--- a/src/websockets.android.js
+++ b/src/websockets.android.js
@@ -75,7 +75,7 @@ var toHashMap = function(obj) {
  * We use a thin shell to just facilitate communication from ANDROID to our JS code
  * We also use this class to try and standardize the messages
  */
-var _WebSocket = org.java_websocket.client.WebSocketClient.extend({
+var _WebSocket = org.java_websocket.client.WebSocketClient.extend('nathanaela.nativescript_websocket.WebSocket', {
     fragmentInfo: {type: 0, data: [], sizes: 0},
     wrapper: null,
     onOpen: function () {

--- a/src/websockets.android.js
+++ b/src/websockets.android.js
@@ -75,7 +75,7 @@ var toHashMap = function(obj) {
  * We use a thin shell to just facilitate communication from ANDROID to our JS code
  * We also use this class to try and standardize the messages
  */
-var _WebSocket = org.java_websocket.client.WebSocketClient.extend('nathanaela.nativescript_websocket.WebSocket', {
+var _WebSocket = org.java_websocket.client.WebSocketClient.extend('nathanaela.nativescript_websockets.WebSocket', {
     fragmentInfo: {type: 0, data: [], sizes: 0},
     wrapper: null,
     onOpen: function () {


### PR DESCRIPTION
This PR is a workaround for issue NativeScript/android-runtime#962.

tl;dr: this PR ensures the Java generator will not use a buggy algorithm to name the class, leading to invalid Java code that won't compile.

By providing a name as a string, the nativescript build process uses that name for the generated subclass.

Unfortunately, this is not documented here:
https://docs.nativescript.org/runtimes/android/generator/extend-class-interface

This behaviour is however included in this article about extending Android's application and activity classes:
https://docs.nativescript.org/runtimes/android/advanced-topics/extend-application-activity

To quote:

```javascript
var Application = android.app.Application.extend("org.myApp.Application", {
```

```typescript
@JavaProxy("org.myApp.Application")
class Application extends android.app.Application {
```

It is also currently used internally by Nativescript to declare and generate such an activity:
https://github.com/NativeScript/NativeScript/blob/4ce45666a5f1ce51c94470b007ec6148453c7e5b/tns-core-modules/ui/frame/activity.android.ts#L9

There shouldn't be any issues involved, but it does affect the following situation. If a single Nativescript app is dependant on this plugin multiple times through it's plugins (and possibly nested again through their dependencies), a seperate Java subclass was probably previously generated per dependency. This change would lead to the generation of a single Java class for that app, regardless of the dependencies. If this plugin is included as a dependency in multiple versions, the multiple classes may be desirable side-effect. (I really hope not...) In which case, this PR would be a breaking change.