### PR TITLE
Update websockets.ios.js

### DIFF
--- a/src/websockets.ios.js
+++ b/src/websockets.ios.js
@@ -305,7 +305,6 @@ NativeWebSockets.prototype.close = function(code, message) {
  * @returns {boolean} - returns false if it is unable to send the message at this time, it will queue them up and try later...
  */
 NativeWebSockets.prototype.send = function(message) {
-    message = message.slice(0);
     var state = this.state();
 
     // If we have a queue, we need to start processing it...
@@ -331,12 +330,12 @@ NativeWebSockets.prototype.send = function(message) {
         if (this._browser) {
             return false;
         }
-        this._queue.push(message);
+        this._queue.push(message.slice(0));
         this._startQueueRunner();
         return false;
     }
 
-    this._send(message);
+    this._send(message.slice(0));
     return true;
 };
 

--- a/src/websockets.ios.js
+++ b/src/websockets.ios.js
@@ -305,6 +305,7 @@ NativeWebSockets.prototype.close = function(code, message) {
  * @returns {boolean} - returns false if it is unable to send the message at this time, it will queue them up and try later...
  */
 NativeWebSockets.prototype.send = function(message) {
+    message = message.slice(0);
     var state = this.state();
 
     // If we have a queue, we need to start processing it...


### PR DESCRIPTION
This patch allows to correcly run nativescript-websockets on iOS. Without this patch,
the same objects are referenced when passed to `this._socket.send`, thus the websocket resend
previous messages.