### PR TITLE
Fixed issue when wrapper became null during close.

### DIFF
--- a/src/websockets.android.js
+++ b/src/websockets.android.js
@@ -98,10 +98,12 @@ var _WebSocket = org.java_websocket.client.WebSocketClient.extend('technology.ma
             // an issue/bug in org.java_websocket.WebSocketImpl.closeConnection(). Regardless, as a workaround we pass control back to
             // closeConnection() prior to passing the notification along so that the readystate gets updated to CLOSED.
             // TODO: remove this when the readystate issue gets resolved.
-			var self = this;
+			      var self = this;
             setTimeout(function() {
-                self.wrapper._notify("close", [self.wrapper, code, reason]);
-                self.wrapper = null;  // Clean up memory
+                if (self.wrapper) {
+                    self.wrapper._notify('close', [self.wrapper, code, reason])
+                    self.wrapper = null;  // Clean up memory
+                } 
             }, 1);
         }
     },


### PR DESCRIPTION
I am using this library as the basis on a project using websockets for STOMP communication. I have experienced an issue which appears to be related to closing the socket, likely a side effect of using this library under the STOMP library, where essentially the wrapper becomes null at some point between the if check and the timeout execution. I understand you are no longer supporting advancement of this library, so I implemented a very small fix to this issue, which I don't believe will cause any problems elsewhere, and will alleviate my issue. Thanks for taking the time to review the change, and please let me know if you would rather I tidy it a little more.