### PR TITLE
Use getbytes instead of toString

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-websockets",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A WebSocket NativeScript module for Android and iOS",
   "main": "websockets",
   "nativescript": {


### PR DESCRIPTION
With iOS13, NSConcreteMutableData.toString() got changed to return something
more user-readable, so it cannot be used anymore for getting the data.

Closes #75 