### PR TITLE
Added connectionLostTimeout option for android.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -88,10 +88,11 @@ The Advanced WebSockets allow you a lot more control over setting up and creatin
 ##### Parameters
 * URL - Url to Open
 * Options
-** protocols - (Array of string) - Valid protocols.  (See Limitation note)
-** timeout - timeout  (Defaults to 60,0000ms on IOS amd 10,000ms on Android, setting this to 0 disables timeouts)
-** allowCellular (ios only, defaults to True) - can disable the WebSocket from going over the cellular network
-** sslSocketFactory (android only, defaults to null) - you can pass in your ssl socket factory you want to use.
+  * protocols - (Array of string) - Valid protocols.  (See Limitation note)
+  * timeout - timeout  (Defaults to 60,0000ms on IOS amd 10,000ms on Android, setting this to 0 disables timeouts)
+  * allowCellular (ios only, defaults to True) - can disable the WebSocket from going over the cellular network
+  * sslSocketFactory (android only, defaults to null) - you can pass in your ssl socket factory you want to use.
+  * connectionLostTimeout (android only, defaults to 60s) - Detect lost connection using ping/pong, forcing a socket disconnect. See [Lost connection detection](https://github.com/TooTallNate/Java-WebSocket/wiki/Lost-connection-detection) for more information.
 
 #### Attaches an event to the WebSocket
 #### .attachEventListener(EventName, function, passedThis)

--- a/src/websockets.android.js
+++ b/src/websockets.android.js
@@ -253,13 +253,13 @@ var NativeWebSockets = function(url, options) {
     this._protocol = options.protocols && options.protocols[0] || "";
 
     this._browser = !!options.browser;
-    this._timeout = options.timeout;
     this._url = url.replace(/\s/g,'+');
-
+    
     //noinspection JSUnresolvedVariable
     this._proxy = options.proxy;
-
+    
     this._timeout = options.timeout || 10000;
+    this._connectionLostTimeout = !isNaN(options.connectionLostTimeout) ? options.connectionLostTimeout : null
 
     this._headers = options.headers || [];
     if (this._debug === true) {
@@ -324,6 +324,10 @@ NativeWebSockets.prototype._reCreate = function() {
     if (proxy) {
         //noinspection JSUnresolvedFunction
         this._socket.setProxy(proxy);
+    }
+
+    if (this._connectionLostTimeout) {
+        this._socket.setConnectionLostTimeout(this._connectionLostTimeout)
     }
 
     // Check for SSL/TLS


### PR DESCRIPTION
Implemented connectionLostTimeout based on https://github.com/TooTallNate/Java-WebSocket/wiki/Lost-connection-detection

I investigated the possibility of supporting this on IOS, however it would require additional changes to the PocketSocket library.

I would greatly appreciate support in having this feature merged and released as it is of large impact in my application which uses this library.