### PR TITLE
Android: url whitespaces

### DIFF
--- a/src/websockets.android.js
+++ b/src/websockets.android.js
@@ -254,7 +254,7 @@ var NativeWebSockets = function(url, options) {
 
     this._browser = !!options.browser;
     this._timeout = options.timeout;
-    this._url = url.replace(/\s/g,'+');
+    this._url = url.replace(/\s/g,'%20');
 
     //noinspection JSUnresolvedVariable
     this._proxy = options.proxy;


### PR DESCRIPTION
Replace whitespace with `%20` instead of `+`.