### PR TITLE
fix: correctly send ArrayBuffer data

### DIFF
--- a/src/websockets-base.ios.js
+++ b/src/websockets-base.ios.js
@@ -361,7 +361,7 @@ class NativeWebSockets {
      * @private
      */
     _send(message) {
-        const nsMsg = NSURLSessionWebSocketMessage.alloc().initWithString(message);
+        const nsMsg = message instanceof ArrayBuffer ? NSURLSessionWebSocketMessage.alloc().initWithData(message) : NSURLSessionWebSocketMessage.alloc().initWithString(message);
 
         // this._nsWebSocketTask
         NSURLSessionWebSocketTask.prototype.sendMessageCompletionHandler.apply(this._nsWebSocketTask, [


### PR DESCRIPTION
When you'd send a message with an ArrayBuffer instead of a string the app would crash with `-[NSDataAdapter dataUsingEncoding:]: unrecognized selector sent to instance ...`

Fixes https://github.com/edusperoni/nativescript-mqtt/issues/18